### PR TITLE
Update jQuery version

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,4 @@
-<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/jekyll-search.js' | relative_url }}"></script>
 <script>


### PR DESCRIPTION
Existing version of jQuery has vulnerabilities. It's not required for the site build, only for keyboard interaction.

We're using a minified version from their CDN, so have updated to most recent version. No regressions detected, but this will need testing

Fix #66