### PR TITLE
Accessibility improvements for screen readers

### DIFF
--- a/_includes/cards-section.html
+++ b/_includes/cards-section.html
@@ -1,62 +1,46 @@
 <section class="white-bg">
   <div class="content categories wrapper">
   <div class="categories-container">
-    <div class="categories-card post-card">
+    <a aria-label="See topics" class="categories-card post-card" tabindex="-1" href="{{site.baseurl}}/#topics">
+      <div class="categories-image">
+        <img alt="Explore topics" src="{{site.baseurl}}/assets/img/layout/topics.svg">
+      </div>
+      <div>
+        <h3>Explore topics and charts</h3>
+        <p>See interactive charts, data sources, definitions, and how and why data was collected. Take and use charts and data for free.</p>
+        <button class="close-button">See topics</button>
+      </div> 
+    </a>  
+    <a aria-label="Find experts" class="categories-card post-card" href="{{site.baseurl}}/experts" tabindex="-1">
         <div class="categories-image">
-          <a href="{{site.baseurl}}/#topics" tabindex="-1" >
-          <img alt="Explore topics" src="{{site.baseurl}}/assets/img/layout/topics.svg">
-          </a>
-        </div>
-        <div>
-          <a tabindex="-1" href="{{site.baseurl}}/#topics">
-          <h3>Explore topics and charts</h3>
-          <p>See interactive charts, data sources, definitions, and how and why data was collected. Take and use charts and data for free.</p>
-          <button class="close-button">See topics</button>
-        </a>
-        </div> 
-    </div>
-    <div class="categories-card post-card">
-        <div class="categories-image">
-          <a href="{{site.baseurl}}/experts" tabindex="-1">
           <img alt="Find experts" src="{{site.baseurl}}/assets/img/layout/experts.svg">
-          </a>
         </div>
         <div>
-          <a tabindex="-1" href="{{site.baseurl}}/experts">
           <h3>Find experts</h3>
             <p>Check out our directory of Pacific data experts, analysts, thinkers, and networks.</p>
             <button class="close-button">Find experts</button>
-          </a>
         </div>
-    </div>
-    <div class="categories-card post-card">
+    </a>
+    <a aria-label="Find reports" class="categories-card post-card" tabindex="-1" href="{{site.baseurl}}/reports">
         <div class="categories-image">
-          <a tabindex="-1" href="{{site.baseurl}}/reports">
           <img alt="Read reports" src="{{site.baseurl}}/assets/img/layout/reports.svg">
-          </a>
         </div>
         <div>
-          <a tabindex="-1" href="{{site.baseurl}}/reports">
           <h3>Read reports and presentations</h3>
           <p>Get information that supports your use of data and provides a deeper understanding of Pacific life in Aotearoa through the lens of data</p>
           <button class="close-button">Find reports</button>
-          </a>
         </div>
-    </div>
-     <div class="categories-card post-card">
+    </a>
+    <a aria-label="Find business figures" class="categories-card post-card" tabindex="-1" href="https://figure.nz/business">
         <div class="categories-image">
-          <a tabindex="-1" href="https://figure.nz/business">
           <img alt="Find business figures" src="{{site.baseurl}}/assets/img/layout/business.svg">
-          </a>
         </div>
         <div>
-          <a tabindex="-1" href="https://figure.nz/business">
           <h3>Find business figures</h3>
           <p>Explore data specific to your industries of work, workforce, and customer base.</p>
           <button class="close-button">Find business figures</button>
-        </a>
         </div>
-    </div>
+    </a>
   </div>
 </div>
 </section>

--- a/_includes/grid-topic-cards.html
+++ b/_includes/grid-topic-cards.html
@@ -5,11 +5,10 @@
   Each card has links, also generated from the YAML of the topic file. In this example, they're set to an external URL, but could be changed to open a page on this site.
   The background colour can be either white or grey. The example is grey, but change to white-bg for white.
 -->
-
-<section class="gray-bg">
-  <div class="content wrapper">
+<a name="topics" aria-label="link to topics" aria-describedby="topics"></a>
+<section id="topics" class="gray-bg">
+    <div class="content wrapper">
       <h2 class="centered-heading">People and Demographics</h2>
-      <a name="topics"></a>
       <ul class="post-card-box clearfix">
           {% for topic in site.topics-people %}
               <li>
@@ -115,5 +114,4 @@
             </li>
             {% endfor %} 
         </ul>
-    </div>
 </section>

--- a/_includes/grid-topic-cards.html
+++ b/_includes/grid-topic-cards.html
@@ -10,92 +10,110 @@
   <div class="content wrapper">
       <h2 class="centered-heading">People and Demographics</h2>
       <a name="topics"></a>
-      <ol class="post-card-box clearfix">
+      <ul class="post-card-box clearfix">
           {% for topic in site.topics-people %}
               <li>
                   <div class="post-card">
-                      <a tabindex="-1" href="{{ topic.link }}" class="post-card-image" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )"></a>
-                      <div class="post-card-body">
-                          <a href="{{ topic.link }}" class="post-card-link"><h3 class="post-card-title">{{ topic.title }}</h3></a>
+                      <a href="{{ topic.link }}">
+                      <div class="post-card-image" role="img" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )">
                       </div>
+                      <div class="post-card-body">
+                        <h3 class="post-card-title">{{ topic.title }}</h3>
+                      </div>
+                    </a>
                   </div>
               </li>
           {% endfor %} 
-      </ol>
+      </ul>
   </div>
   <div class="content wrapper">
     <h2 class="centered-heading">Wellbeing</h2>
-    <ol class="post-card-box clearfix">
+    <ul class="post-card-box clearfix">
         {% for topic in site.topics-wellbeing %}
-            <li>
-                <div class="post-card">
-                    <a tabindex="-1" href="{{ topic.link }}" class="post-card-image" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )"></a>
-                    <div class="post-card-body">
-                        <a href="{{ topic.link }}" class="post-card-link"><h3 class="post-card-title">{{ topic.title }}</h3></a>
-                    </div>
+        <li>
+            <div class="post-card">
+                <a href="{{ topic.link }}">
+                <div class="post-card-image" role="img" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )">
                 </div>
-            </li>
+                <div class="post-card-body">
+                  <h3 class="post-card-title">{{ topic.title }}</h3>
+                </div>
+              </a>
+            </div>
+        </li>
         {% endfor %} 
-    </ol>
+    </ul>
     </div>
     <div class="content wrapper">
         <h2 class="centered-heading">Health and Disability</h2>
-        <ol class="post-card-box clearfix">
+        <ul class="post-card-box clearfix">
             {% for topic in site.topics-health %}
-                <li>
-                    <div class="post-card">
-                        <a tabindex="-1" href="{{ topic.link }}" class="post-card-image" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )"></a>
-                        <div class="post-card-body">
-                            <a href="{{ topic.link }}" class="post-card-link"><h3 class="post-card-title">{{ topic.title }}</h3></a>
-                        </div>
+            <li>
+                <div class="post-card">
+                    <a href="{{ topic.link }}">
+                    <div class="post-card-image" role="img" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )">
                     </div>
-                </li>
+                    <div class="post-card-body">
+                      <h3 class="post-card-title">{{ topic.title }}</h3>
+                    </div>
+                  </a>
+                </div>
+            </li>
             {% endfor %} 
-        </ol>
+        </ul>
     </div>
     <div class="content wrapper">
         <h2 class="centered-heading">Education</h2>
-        <ol class="post-card-box clearfix">
+        <ul class="post-card-box clearfix">
             {% for topic in site.topics-education %}
-                <li>
-                    <div class="post-card">
-                        <a tabindex="-1" href="{{ topic.link }}" class="post-card-image" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )"></a>
-                        <div class="post-card-body">
-                            <a href="{{ topic.link }}" class="post-card-link"><h3 class="post-card-title">{{ topic.title }}</h3></a>
-                        </div>
+            <li>
+                <div class="post-card">
+                    <a href="{{ topic.link }}">
+                    <div class="post-card-image" role="img" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )">
                     </div>
-                </li>
+                    <div class="post-card-body">
+                      <h3 class="post-card-title">{{ topic.title }}</h3>
+                    </div>
+                  </a>
+                </div>
+            </li>
             {% endfor %} 
-        </ol>
+        </ul>
     </div>
     <div class="content wrapper">
         <h2 class="centered-heading">Economy, employment, and business</h2>
-        <ol class="post-card-box clearfix">
+        <ul class="post-card-box clearfix">
             {% for topic in site.topics-biz %}
-                <li>
-                    <div class="post-card">
-                        <a tabindex="-1" href="{{ topic.link }}" class="post-card-image" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )"></a>
-                        <div class="post-card-body">
-                            <a href="{{ topic.link }}" class="post-card-link"><h3 class="post-card-title">{{ topic.title }}</h3></a>
-                        </div>
+            <li>
+                <div class="post-card">
+                    <a href="{{ topic.link }}">
+                    <div class="post-card-image" role="img" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/list/{{ topic.data }}.jpg' )">
                     </div>
-                </li>
+                    <div class="post-card-body">
+                      <h3 class="post-card-title">{{ topic.title }}</h3>
+                    </div>
+                  </a>
+                </div>
+            </li>
             {% endfor %} 
-        </ol>
+        </ul>
     </div>
     <div class="content wrapper">
         <h2 class="centered-heading">Pacific Countries</h2>
-        <ol class="post-card-box clearfix">
+        <ul class="post-card-box clearfix">
             {% for topic in site.topics-countries %}
-                <li>
-                    <div class="post-card">
-                        <a tabindex="-1" href="{{ topic.link }}" class="post-card-image"  aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/flags/{{ topic.data }}.svg' )"></a>
-                        <div class="post-card-body">
-                            <a href="{{ topic.link }}" class="post-card-link"><h3 class="post-card-title">{{ topic.title }}</h3></a>
-                        </div>
+            <li>
+                <div class="post-card">
+                    <a href="{{ topic.link }}">
+                    <div class="post-card-image" role="img" aria-label="{{topic.title}}" style="background-image: url( '{{site.baseurl}}/assets/img/flags/{{ topic.data }}.svg' )">
                     </div>
-                </li>
+                    <div class="post-card-body">
+                      <h3 class="post-card-title">{{ topic.title }}</h3>
+                    </div>
+                  </a>
+                </div>
+            </li>
             {% endfor %} 
-        </ol>
+        </ul>
     </div>
 </section>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,7 +1,7 @@
 <nav class="main-nav" aria-label="Main menu">
-    <button aria-label="Close menu" class="menu-icon-close"><i class="fa fa-times" aria-hidden="true"></i></button>
+    <button aria-label="Close menu" class="menu-icon-close" id="menu-close-button"><i class="fa fa-times" aria-hidden="true"></i></button>
     <ul aria-label="Main menu items">
-        <li><a href="{{site.baseurl}}{% link index.md %}">Home</a></li>
+        <li><a id="menu-first" href="{{site.baseurl}}{% link index.md %}">Home</a></li>
         <li><a href="{{site.baseurl}}{% link about.md %}">About</a></li>
         <li><a href="{{site.baseurl}}{% link reports.md %}">Reports</a></li>
         <li><a href="{{site.baseurl}}{% link experts.md %}">Find Experts</a></li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,5 +1,5 @@
-<nav class="main-nav">
-    <span tabindex="0" class="menu-icon-close"><i class="fa fa-times" aria-hidden="true"></i></span>
+<nav class="main-nav" aria-label="Main menu">
+    <button aria-label="Close menu" class="menu-icon-close"><i class="fa fa-times" aria-hidden="true"></i></button>
     <ul>
         <li><a href="{{site.baseurl}}{% link index.md %}">Home</a></li>
         <li><a href="{{site.baseurl}}{% link about.md %}">About</a></li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,6 +1,6 @@
 <nav class="main-nav" aria-label="Main menu">
     <button aria-label="Close menu" class="menu-icon-close"><i class="fa fa-times" aria-hidden="true"></i></button>
-    <ul>
+    <ul aria-label="Main menu items">
         <li><a href="{{site.baseurl}}{% link index.md %}">Home</a></li>
         <li><a href="{{site.baseurl}}{% link about.md %}">About</a></li>
         <li><a href="{{site.baseurl}}{% link reports.md %}">Reports</a></li>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -66,7 +66,7 @@
                     </div>
                 </div>
             </section>
-            <div class="svg-stripe">  
+            <div aria-hidden="true" class="svg-stripe">  
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none" class="svg-stripe hp-topics-svg-top" focusable="false">
                     <polygon fill="#fbf280" points="0,85 100,1 100,6 0,90"></polygon>
                     <polygon fill="#4db7c6" points="0,90 100,6 100,11 0,95"></polygon>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -31,7 +31,7 @@
             <div class="wrapper">
                 <div class="header-flex">
                     <div class="menu-icon-container">
-                        <button class="menu-icon" aria-label="Main menu"><i class="fa fa-bars" aria-hidden="true"></i></button>
+                        <button class="menu-icon" aria-label="Main menu" aria-expanded="false"><i class="fa fa-bars" aria-hidden="true"></i></button>
                     </div>
                     {% include navigation.html %}
                     <p class="logo"><a href="{{site.baseurl}}/">{{site.title}}</a></p>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -31,7 +31,7 @@
             <div class="wrapper">
                 <div class="header-flex">
                     <div class="menu-icon-container">
-                        <span tabindex="0" class="menu-icon"><i class="fa fa-bars" aria-hidden="true"></i></span>
+                        <button class="menu-icon" aria-label="Main menu"><i class="fa fa-bars" aria-hidden="true"></i></button>
                     </div>
                     {% include navigation.html %}
                     <p class="logo"><a href="{{site.baseurl}}/">{{site.title}}</a></p>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -31,7 +31,7 @@
             <div class="wrapper">
                 <div class="header-flex">
                     <div class="menu-icon-container">
-                        <button class="menu-icon" aria-label="Main menu" aria-expanded="false"><i class="fa fa-bars" aria-hidden="true"></i></button>
+                        <button id="home-menu-button" class="menu-icon" aria-label="Main menu" aria-expanded="false"><i class="fa fa-bars" aria-hidden="true"></i></button>
                     </div>
                     {% include navigation.html %}
                     <p class="logo"><a href="{{site.baseurl}}/">{{site.title}}</a></p>

--- a/_sass/parts/_categories.scss
+++ b/_sass/parts/_categories.scss
@@ -2,6 +2,9 @@
   display: flex;
   flex-flow: row wrap;
   margin: 0 0 1rem 0;
+  a {
+    text-decoration: none;
+  }
   .categories-card {
     border-radius: 3px;
     display: flex;
@@ -22,9 +25,6 @@
         justify-content: center;
       }
       
-    }
-    a {
-      text-decoration: none;
     }
     h4 {
       margin-top: 0;

--- a/_sass/parts/_header.scss
+++ b/_sass/parts/_header.scss
@@ -33,6 +33,10 @@
   background-color: $white;
   padding: 25px 30px;
   transform: translate3d(-300px, 0, 0);
+  .menu-icon-close {
+    border: 0;
+    background-color: white;
+  }
   ul {
     padding: 15px 0 0;
     margin: 0;

--- a/_sass/parts/_post-card.scss
+++ b/_sass/parts/_post-card.scss
@@ -33,6 +33,9 @@
   &::hover {
     box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
   }
+  a {
+    text-decoration: none;
+  }
   .post-card-image {
     display: block;
     width: 100%;
@@ -71,6 +74,7 @@
       line-height: 1em;
       color: $post-card-header-colour;
       margin: 0 0 10px;
+      text-decoration: none;
       &:hover {
         opacity: .8;
       }

--- a/_sass/parts/_top-nav.scss
+++ b/_sass/parts/_top-nav.scss
@@ -3,6 +3,8 @@
 
   .menu-icon{
     color: $menu-header-colour;
+    border: 0;
+    background-color: white;
   }
 
   .logo {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,21 +8,47 @@ $(function () {
   var searchInput = $('#search-input')
 
   // Menu Settings
+  
   $('.menu-icon, .menu-icon-close').click(function (e) {
     e.preventDefault()
     e.stopPropagation()
     flexContainer.toggleClass('active') 
     sideNav.toggleClass('active')
     this.setAttribute("aria-expanded", 'true')
+    // if class toggle is active, focus on close button. Otherwise, focus on menu button.
+    if (sideNav[0].classList[1] === 'active') {
+      setTimeout(function(){
+        document.getElementById("menu-close-button").focus()
+      }, 200)
+    } else {
+      setTimeout(function(){
+        document.getElementById("home-menu-button").focus()
+      }, 200)
+    }
   })
 
   $('.menu-icon, .menu-icon-close').keydown(function (e) {
-    if(e.key === 'Enter') {
+    // if space, focus moves to first list item in menu
+    if (e.key === " ") {
       e.preventDefault()
       e.stopPropagation()
       flexContainer.toggleClass('active') 
       sideNav.toggleClass('active')
       this.setAttribute("aria-expanded", 'true')
+      setTimeout(function(){
+        document.getElementById("menu-first").focus()
+      }, 200)
+    }
+    // if enter, focus moves to close button in menu.
+    else if(e.key === 'Enter') {
+      e.preventDefault()
+      e.stopPropagation()
+      flexContainer.toggleClass('active') 
+      sideNav.toggleClass('active')
+      this.setAttribute("aria-expanded", 'true')
+      setTimeout(function(){
+        document.getElementById("menu-close-button").focus()
+      }, 200)
     }
   })
 
@@ -32,6 +58,9 @@ $(function () {
       flexContainer.removeClass('active') 
       sideNav.removeClass('active')
       navButton[0].setAttribute("aria-expanded", 'false')
+      setTimeout(function(){
+        document.getElementById("home-menu-button").focus()
+      }, 200)
     }
   })
 
@@ -41,6 +70,9 @@ $(function () {
         flexContainer.removeClass('active')
         sideNav.removeClass('active')
         navButton[0].setAttribute("aria-expanded", 'false')
+        setTimeout(function(){
+          document.getElementById("home-menu-button").focus()
+        }, 200)
     }
   })
 
@@ -51,6 +83,9 @@ $(function () {
         flexContainer.removeClass('active')
         sideNav.removeClass('active')
         navButton[0].setAttribute("aria-expanded", 'false')
+        setTimeout(function(){
+          document.getElementById("home-menu-button").focus()
+        }, 200)
       } else if (searchBox.hasClass('search-active')) {
         searchBox.removeClass('search-active')
       }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,11 +1,11 @@
 $(function () {
   // Cache variables for increased performance on devices with slow CPUs.
   var flexContainer = $('div.flex-container')
+  var navButton = $('button.menu-icon')
   var sideNav = $('nav.main-nav')
   var searchBox = $('.search-box')
   var searchClose = $('.search-icon-close')
   var searchInput = $('#search-input')
-  var sideNavClose = $('span.menu-icon-close')
 
   // Menu Settings
   $('.menu-icon, .menu-icon-close').click(function (e) {
@@ -13,6 +13,7 @@ $(function () {
     e.stopPropagation()
     flexContainer.toggleClass('active') 
     sideNav.toggleClass('active')
+    this.setAttribute("aria-expanded", 'true')
   })
 
   $('.menu-icon, .menu-icon-close').keydown(function (e) {
@@ -21,6 +22,7 @@ $(function () {
       e.stopPropagation()
       flexContainer.toggleClass('active') 
       sideNav.toggleClass('active')
+      this.setAttribute("aria-expanded", 'true')
     }
   })
 
@@ -29,14 +31,16 @@ $(function () {
     if (flexContainer.hasClass('active') && e.target.tagName !== 'A') {
       flexContainer.removeClass('active') 
       sideNav.removeClass('active')
+      navButton[0].setAttribute("aria-expanded", 'false')
     }
   })
 
   // Press Enter key to close menu when focus is on close icon
-  $('span.menu-icon-close').keydown(function (e) {
+  $('.menu-icon-close').keydown(function (e) {
     if (e.key === 'Enter') {
         flexContainer.removeClass('active')
         sideNav.removeClass('active')
+        navButton[0].setAttribute("aria-expanded", 'false')
     }
   })
 
@@ -46,6 +50,7 @@ $(function () {
       if (flexContainer.hasClass('active')) {
         flexContainer.removeClass('active')
         sideNav.removeClass('active')
+        navButton[0].setAttribute("aria-expanded", 'false')
       } else if (searchBox.hasClass('search-active')) {
         searchBox.removeClass('search-active')
       }


### PR DESCRIPTION
This PR incorporates a lot of refactoring for screen reader access including:
- cleaning up HTML structure to remove unnecessary links
- removing decorative images from screen reader view
- improving menu access toggling functions
- improving menu button access

The JS is a bit messy and could probably do with a refactor but I think it works OK.

For menu, you should be able to:
- use enter to open menu and have focus move to close button
- use enter to close menu and have focus move back to menu button
- use space bar to open menu and have focus move to first link
- using a screen reader, see menu, open menu, and have focus shift into menu, and vice versa for closing menu.